### PR TITLE
Dont modify build-book.yaml directly

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -11,7 +11,7 @@ on:
       environment_file:
         description: 'Name of conda environment file'
         required: false
-        default: 'website/environment.yml'
+        default: 'environment.yml'
         type: string
       path_to_notebooks:
         description: 'Location of the JupyterBook source relative to repo root'

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -19,6 +19,7 @@ jobs:
 # So the only way to fix this rn is to manually copy the PR content here and reference it locally. Silly.
     uses: ./.github/workflows/build-book.yaml 
     with:
+      environment_file: 'website/environment.yml'
       environment_name: climsim-docs-env
       path_to_notebooks: 'website'
       build_command: 'cp ../README.md ../fig_1.png .; jupyter-book build . --builder singlehtml'


### PR DESCRIPTION
Instead of editing `build-book.yaml` I am giving the new environment path in the `publish-website.yaml`.