### PR TITLE
Include online_testing in gh action copy

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -17,7 +17,7 @@ jobs:
       environment_file: 'website/environment.yml'
       environment_name: climsim-docs-env
       path_to_notebooks: 'website'
-      build_command: 'cp -r ../README.md ../ARCHITECTURE.md ../figures ../demo_notebooks ../evaluation .; jupyter-book build .'
+      build_command: 'cp -r ../README.md ../ARCHITECTURE.md ../figures ../demo_notebooks ../online_testing ../evaluation .; jupyter-book build .'
       # this is a bit hacky, but the only way to 'inject' a shell command before the build. 
       output_path: '_build/html'
   deploy:


### PR DESCRIPTION
#98 is not showing up properly. This is due to the subtlety that we want to have md files show up in the readme but also the book (and thus we have to copy files from root to the website dir at build time).  Thanks @zyhu-hu for catching this. If we expect more folks to contribute, we should document this better (and potentially implement a website preview).